### PR TITLE
Fix code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,20 @@
 const express = require("express"),
-  fs = require("fs");
+  fs = require("fs"),
+  RateLimit = require("express-rate-limit");
 
 const json = JSON.parse(fs.readFileSync("./video.json", "utf8"));
 const port = 3000;
 const app = express();
+
+// set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
+// apply rate limiter to all requests
+app.use(limiter);
+
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "call-bind": "^1.0.7",
     "ejs": "^3.1.10",
     "express": "^4.21.0",
-    "jsdom": "^25.0.1"
+    "jsdom": "^25.0.1",
+    "express-rate-limit": "^7.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2"


### PR DESCRIPTION
Fixes [https://github.com/sozanliberalarts/Libet/security/code-scanning/3](https://github.com/sozanliberalarts/Libet/security/code-scanning/3)

To fix the problem, we will introduce rate limiting to the Express application using the `express-rate-limit` package. This will help prevent denial-of-service attacks by limiting the number of requests a client can make within a specified time window.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `index.js` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to all routes in the application.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
