### PR TITLE
Fix code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 const express = require("express"),
   fs = require("fs"),
+  path = require("path"),
   RateLimit = require("express-rate-limit");
+
+const SAFE_ROOT = path.resolve(__dirname, 'public');
 
 const json = JSON.parse(fs.readFileSync("./video.json", "utf8"));
 const port = 3000;
@@ -38,8 +41,12 @@ app.post("/api/upload",(req, res) => {
   res.send("");
 });
 app.use((req, res, next) => {
-  const url = __dirname + req.originalUrl;
-  fs.existsSync(url) ? res.sendFile(url) : next();
+  const requestedPath = path.resolve(SAFE_ROOT, '.' + req.originalUrl);
+  if (requestedPath.startsWith(SAFE_ROOT) && fs.existsSync(requestedPath)) {
+    res.sendFile(requestedPath);
+  } else {
+    next();
+  }
 }, notFound);
 
 app.listen(port, () => console.log(`running on ${port}`));


### PR DESCRIPTION
Fixes [https://github.com/sozanliberalarts/Libet/security/code-scanning/1](https://github.com/sozanliberalarts/Libet/security/code-scanning/1)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root directory. We can achieve this by normalizing the path using `path.resolve` and then checking that the normalized path starts with the root directory. This will prevent path traversal attacks by ensuring that the file path does not escape the intended directory.

1. Import the `path` module to use `path.resolve` for normalizing the file path.
2. Define a safe root directory where the files are intended to be served from.
3. Normalize the constructed file path using `path.resolve`.
4. Check that the normalized path starts with the root directory.
5. If the path is valid, serve the file; otherwise, call the `next` middleware to handle the request.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
